### PR TITLE
fix(telegram): resolve agent bot client from MCP URL

### DIFF
--- a/src/Fleet.Orchestrator/Services/ContainerProvisioningService.cs
+++ b/src/Fleet.Orchestrator/Services/ContainerProvisioningService.cs
@@ -854,7 +854,15 @@ public sealed class ContainerProvisioningService(
             .OrderBy(e => e.McpName)
             .ToDictionary(
                 e => e.McpName,
-                e => (object)new { type = e.TransportType, url = e.Url });
+                e =>
+                {
+                    // Append ?agent={name} to fleet-telegram URL so the server knows
+                    // which bot client to use without relying on the LLM to pass it.
+                    var url = e.McpName == "fleet-telegram"
+                        ? $"{e.Url.TrimEnd('/')}?agent={agent.Name}"
+                        : e.Url;
+                    return (object)new { type = e.TransportType, url };
+                });
 
         return JsonSerializer.Serialize(new { mcpServers }, IndentedJson);
     }

--- a/src/Fleet.Telegram/Program.cs
+++ b/src/Fleet.Telegram/Program.cs
@@ -4,6 +4,7 @@ var builder = WebApplication.CreateBuilder(args);
 
 builder.Services.AddSingleton<BotClientFactory>();
 builder.Services.AddHostedService<PeerConfigHostedService>();
+builder.Services.AddHttpContextAccessor();
 
 builder.Services
     .AddMcpServer()

--- a/src/Fleet.Telegram/Tools/GetChatInfoTool.cs
+++ b/src/Fleet.Telegram/Tools/GetChatInfoTool.cs
@@ -9,7 +9,7 @@ using Telegram.Bot.Types;
 namespace Fleet.Telegram.Tools;
 
 [McpServerToolType]
-public sealed class GetChatInfoTool(BotClientFactory factory, ILogger<GetChatInfoTool> logger)
+public sealed class GetChatInfoTool(BotClientFactory factory, IHttpContextAccessor httpContextAccessor, ILogger<GetChatInfoTool> logger)
 {
     [McpServerTool(Name = "get_chat_info")]
     [Description("Get basic info (title, type) for a Telegram chat ID. Useful for verifying chat IDs before use. Returns {\"ok\":true,\"chat_id\":N,\"title\":\"...\",\"type\":\"...\"} or {\"ok\":false,\"error\":\"...\"}")]
@@ -18,6 +18,9 @@ public sealed class GetChatInfoTool(BotClientFactory factory, ILogger<GetChatInf
         [Description("Agent name to query with (falls back to notifier bot if unknown)")] string agent_name = "",
         CancellationToken cancellationToken = default)
     {
+        if (string.IsNullOrWhiteSpace(agent_name))
+            agent_name = httpContextAccessor.HttpContext?.Request.Query["agent"].FirstOrDefault() ?? "";
+
         var client = factory.GetClient(agent_name);
         if (client is null)
         {

--- a/src/Fleet.Telegram/Tools/SendMessageTool.cs
+++ b/src/Fleet.Telegram/Tools/SendMessageTool.cs
@@ -9,7 +9,7 @@ using Telegram.Bot.Types.Enums;
 namespace Fleet.Telegram.Tools;
 
 [McpServerToolType]
-public sealed class SendMessageTool(BotClientFactory factory, ILogger<SendMessageTool> logger)
+public sealed class SendMessageTool(BotClientFactory factory, IHttpContextAccessor httpContextAccessor, ILogger<SendMessageTool> logger)
 {
     private const int TelegramMaxLength = 4096;
 
@@ -22,6 +22,11 @@ public sealed class SendMessageTool(BotClientFactory factory, ILogger<SendMessag
         [Description("Parse mode for message formatting: HTML, Markdown, or MarkdownV2. Omit for plain text.")] string parse_mode = "",
         CancellationToken cancellationToken = default)
     {
+        // If the LLM didn't pass agent_name, resolve from the ?agent= query parameter
+        // baked into the MCP URL at provision time.
+        if (string.IsNullOrWhiteSpace(agent_name))
+            agent_name = httpContextAccessor.HttpContext?.Request.Query["agent"].FirstOrDefault() ?? "";
+
         // Accept chat_id as string or integer — LLM agents often serialize numeric IDs as strings
         if (!long.TryParse(chat_id?.Trim(), out var chatIdLong))
             return JsonSerializer.Serialize(new { ok = false, error = $"Invalid chat_id '{chat_id}' — must be a numeric value" });


### PR DESCRIPTION
## Summary

- LLM agents call `send_message` / `get_chat_info` without passing `agent_name`, causing fleet-telegram to fall back to the notifier bot instead of using the agent's dedicated bot client
- Fix: embed the agent name in the fleet-telegram MCP URL (`?agent={name}`) at provision time via `GenerateMcpJson`, and read it server-side via `IHttpContextAccessor` when the parameter is missing
- Both `SendMessageTool` and `GetChatInfoTool` now resolve agent identity from the URL query string as fallback

## Test plan

- [ ] Provision a CTO agent and verify `.mcp.json` contains `fleet-telegram` URL with `?agent={name}`
- [ ] Have the CTO agent call `send_message` without `agent_name` — should use its dedicated bot, not notifier
- [ ] Verify `dotnet test` passes (146/146 confirmed locally)