### PR TITLE
fix(workflows): needs_human_review escalates to CEO gate instead of aborting

### DIFF
--- a/seed.example.json
+++ b/seed.example.json
@@ -153,6 +153,36 @@
             }
           },
           {
+            "on": "{{vars.issue_number | default: ''}}",
+            "name": "check_issue_number",
+            "type": "branch",
+            "cases": {
+              "": {
+                "type": "sequence",
+                "steps": [
+                  {
+                    "name": "notify_design_failed",
+                    "type": "delegate",
+                    "target": "{{config.CtoAgent}}",
+                    "instruction": "Post to Telegram group: UweDesignToPrWorkflow aborted — design phase did not return a valid issue number. Design result: {{vars.design_result | default: '(empty)'}}. No implementation workflow will be launched. Check the UweDesignWorkflow child for details.",
+                    "ignoreFailure": true,
+                    "timeoutMinutes": 5
+                  },
+                  {
+                    "on": "break",
+                    "name": "ctrl_abort",
+                    "type": "branch",
+                    "cases": {
+                      "break": {
+                        "type": "break"
+                      }
+                    }
+                  }
+                ]
+              }
+            }
+          },
+          {
             "name": "set_impl_attrs",
             "type": "set_attribute",
             "attributes": {
@@ -255,16 +285,7 @@
                             "name": "notify_needs_human_consensus",
                             "type": "delegate",
                             "target": "{{config.CtoAgent}}",
-                            "instruction": "Post to Telegram group: DesignWorkflow for issue {{vars.issue_result | extract: 'ISSUE_NUMBER:\\s*(\\d+)'}} in {{input.Repo}} — consensus review flagged needs_human_review. Manual intervention required. Reasoning: {{vars.consensus_out.ConsolidatedReasoning}}",
-                            "ignoreFailure": true,
-                            "timeoutMinutes": 5
-                          },
-                          {
-                            "name": "emit_needs_human_error",
-                            "type": "delegate",
-                            "target": "{{config.CtoAgent}}",
-                            "outputVar": "workflow_result",
-                            "instruction": "Output exactly: ERROR:needs_human_review",
+                            "instruction": "Post to Telegram group: DesignWorkflow for issue {{vars.issue_result | extract: 'ISSUE_NUMBER:\\s*(\\d+)'}} in {{input.Repo}} — consensus review flagged needs_human_review. Escalating to CEO approval gate. Reasoning: {{vars.consensus_out.ConsolidatedReasoning}}",
                             "ignoreFailure": true,
                             "timeoutMinutes": 5
                           },


### PR DESCRIPTION
## Summary
- **UweDesignWorkflow**: `needs_human_review` consensus verdict no longer sets `ERROR:` and skips the CEO gate — it now falls through to the CEO approval signal, letting the CEO approve/reject/request changes
- **UweDesignToPrWorkflow**: added `check_issue_number` guard between design phase and implementation launch — if no valid issue number was extracted, notifies CTO and aborts instead of launching `UwePrImplementationWorkflow` with `IssueNumber=N/A`

**Root cause**: When consensus flagged `needs_human_review`, the workflow emitted `ERROR:needs_human_review` → `check_early_exit_before_ceo` caught the `ERROR` prefix and broke out of the design loop → CEO gate was never reached → workflow returned the error string → parent extracted no issue number → launched implementation with empty inputs → developer agent failed on a no-op task.

## Test plan
- [ ] Run UweDesignToPrWorkflow where consensus returns `needs_human_review` — verify CEO gate is reached
- [ ] Approve at CEO gate — verify workflow returns valid `{IssueNumber: N}` and implementation launches correctly
- [ ] Run UweDesignToPrWorkflow where design phase errors — verify `check_issue_number` aborts and notifies CTO