### PR TITLE
fix: log claude error results and failed warmups instead of swallowing them

### DIFF
--- a/src/Fleet.Agent/Services/ClaudeExecutor.cs
+++ b/src/Fleet.Agent/Services/ClaudeExecutor.cs
@@ -295,6 +295,11 @@ public sealed class ClaudeExecutor : IAgentExecutor
                         };
                     }
 
+                    if (evt.Type == "result" && progress.IsErrorResult)
+                    {
+                        _logger.LogError("Claude result reported error: {Result}", progress.FinalResult ?? "(no message)");
+                    }
+
                     yield return progress;
 
                     // "result" event means this response is complete — process stays alive

--- a/src/Fleet.Agent/Services/TaskManager.cs
+++ b/src/Fleet.Agent/Services/TaskManager.cs
@@ -508,7 +508,11 @@ public sealed class TaskManager
 
             if (lastResult is not null)
             {
-                var marker = errorResult ? " [incomplete — hit limit]" : "";
+                // IsErrorResult covers max-turns exhaustion, auth failures, RPC errors and
+                // executor crashes alike — so the marker must not assert a specific cause.
+                // It previously claimed "hit limit" for every one of them, which sends
+                // anyone debugging a dead executor after the wrong problem.
+                var marker = errorResult ? " [incomplete — executor reported an error]" : "";
                 // Send the final text to Telegram, but relay ALL assistant texts
                 // so that agent addresses from intermediate turns aren't lost
                 await SendWithStatsAsync($"{Prefix()}{lastResult}{marker}");
@@ -520,6 +524,16 @@ public sealed class TaskManager
                 if (isSessionTask)
                     _sessions.ClearSession(chatId);
                 var errorMsg = $"Task failed: {lastError}";
+                await SendWithStatsAsync($"{Prefix()}{errorMsg}");
+                OnTaskCompleted?.Invoke(chatId, errorMsg, relaySender, source, true, correlationId, relayTaskId);
+            }
+            else if (errorResult)
+            {
+                // A result event flagged as an error but carrying no text: the turn failed
+                // and produced nothing. Reporting "Done!" here is what let a dead executor
+                // look healthy — the error flag must survive even with no output to show.
+                var errorMsg = "Task failed: executor reported an error and produced no output";
+                _logger.LogError("Task #{TaskId} for chat {ChatId}: {Error}", taskId, chatId, errorMsg);
                 await SendWithStatsAsync($"{Prefix()}{errorMsg}");
                 OnTaskCompleted?.Invoke(chatId, errorMsg, relaySender, source, true, correlationId, relayTaskId);
             }

--- a/src/Fleet.Agent/Services/WarmupService.cs
+++ b/src/Fleet.Agent/Services/WarmupService.cs
@@ -37,7 +37,10 @@ public sealed class WarmupService : BackgroundService
             {
                 if (progress.EventType == "result")
                 {
-                    _logger.LogInformation("WarmupService: warmup complete — executor process is ready");
+                    if (progress.IsErrorResult)
+                        _logger.LogError("WarmupService: warmup returned error — executor may be misconfigured: {Result}", progress.FinalResult ?? "(no message)");
+                    else
+                        _logger.LogInformation("WarmupService: warmup complete — executor process is ready");
                     break;
                 }
             }

--- a/tests/Fleet.Agent.Tests/TaskFailureReportingTests.cs
+++ b/tests/Fleet.Agent.Tests/TaskFailureReportingTests.cs
@@ -1,0 +1,143 @@
+using Fleet.Agent.Abstractions;
+using Fleet.Agent.Configuration;
+using Fleet.Agent.Models;
+using Fleet.Agent.Services;
+using Microsoft.Extensions.Logging.Abstractions;
+using Microsoft.Extensions.Options;
+using NSubstitute;
+
+namespace Fleet.Agent.Tests;
+
+/// <summary>
+/// Verifies that a turn the executor flagged as an error is never reported as a success.
+///
+/// The gap these cover (issue #225): a "result" event with IsError set but no text fell
+/// through to the "Done! (no text output)" branch, which invoked OnTaskCompleted with
+/// isError=false. A dead executor — expired auth after a host power-off, a crashed
+/// app-server — therefore looked identical to a healthy idle one at every layer above.
+/// </summary>
+public class TaskFailureReportingTests
+{
+    private static async IAsyncEnumerable<AgentProgress> YieldResult(string? finalResult, bool isError)
+    {
+        yield return new AgentProgress
+        {
+            Summary = finalResult ?? "result",
+            EventType = "result",
+            FinalResult = finalResult,
+            IsErrorResult = isError,
+        };
+        await Task.CompletedTask;
+    }
+
+    private static TaskManager BuildManager(IAgentExecutor executor, IMessageSink sink)
+    {
+        var options = Options.Create(new AgentOptions { Name = "test", Role = "test", WorkDir = "/tmp", MaxConcurrentTasks = 5 });
+        var tm = new TaskManager(options, executor, new SessionManager(), NullLogger<TaskManager>.Instance);
+        tm.Sink = sink;
+        return tm;
+    }
+
+    /// <summary>Runs one task to completion and returns what OnTaskCompleted reported.</summary>
+    private static async Task<(string Text, bool IsError)> RunTask(long chatId, string? finalResult, bool isError)
+    {
+        var executor = Substitute.For<IAgentExecutor>();
+        executor
+            .ExecuteAsync(Arg.Any<string>(), Arg.Any<IReadOnlyList<MessageImage>?>(),
+                Arg.Any<IReadOnlyList<MessageDocument>?>(), Arg.Any<CancellationToken>())
+            .Returns(_ => YieldResult(finalResult, isError));
+
+        var sink = Substitute.For<IMessageSink>();
+        var tm = BuildManager(executor, sink);
+
+        var completed = new TaskCompletionSource<(string, bool)>();
+        tm.OnTaskCompleted += (_, text, _, _, err, _, _) => completed.TrySetResult((text, err));
+
+        tm.StartTask(chatId: chatId, task: "ping", displayText: "ping",
+            isSessionTask: false, source: TaskSource.UserMessage);
+
+        return await completed.Task.WaitAsync(TimeSpan.FromSeconds(5));
+    }
+
+    [Fact]
+    public async Task ErrorResult_WithNoOutput_IsReportedAsFailure()
+    {
+        var (text, isError) = await RunTask(chatId: 101, finalResult: null, isError: true);
+
+        Assert.True(isError, "a turn the executor flagged as an error must not complete with isError=false");
+        Assert.DoesNotContain("Done!", text);
+        Assert.Contains("Task failed", text);
+    }
+
+    [Fact]
+    public async Task ErrorResult_WithNoOutput_TellsTheUserItFailed()
+    {
+        var executor = Substitute.For<IAgentExecutor>();
+        executor
+            .ExecuteAsync(Arg.Any<string>(), Arg.Any<IReadOnlyList<MessageImage>?>(),
+                Arg.Any<IReadOnlyList<MessageDocument>?>(), Arg.Any<CancellationToken>())
+            .Returns(_ => YieldResult(null, isError: true));
+
+        var sink = Substitute.For<IMessageSink>();
+        var tm = BuildManager(executor, sink);
+
+        var completed = new TaskCompletionSource();
+        tm.OnTaskCompleted += (_, _, _, _, _, _, _) => completed.TrySetResult();
+
+        tm.StartTask(chatId: 102, task: "ping", displayText: "ping",
+            isSessionTask: false, source: TaskSource.UserMessage);
+
+        await completed.Task.WaitAsync(TimeSpan.FromSeconds(5));
+
+        await sink.Received().SendTextAsync(
+            102,
+            Arg.Is<string>(s => s.Contains("Task failed") && !s.Contains("Done!")),
+            Arg.Any<CancellationToken>());
+    }
+
+    [Fact]
+    public async Task CleanResult_WithNoOutput_StillReportsSuccess()
+    {
+        var (text, isError) = await RunTask(chatId: 103, finalResult: null, isError: false);
+
+        Assert.False(isError);
+        Assert.Contains("Done!", text);
+    }
+
+    [Fact]
+    public async Task ErrorResult_WithText_DoesNotClaimTheCauseWasATurnLimit()
+    {
+        var executor = Substitute.For<IAgentExecutor>();
+        executor
+            .ExecuteAsync(Arg.Any<string>(), Arg.Any<IReadOnlyList<MessageImage>?>(),
+                Arg.Any<IReadOnlyList<MessageDocument>?>(), Arg.Any<CancellationToken>())
+            .Returns(_ => YieldResult("Invalid API key · Please run /login", isError: true));
+
+        var sink = Substitute.For<IMessageSink>();
+        var tm = BuildManager(executor, sink);
+
+        var completed = new TaskCompletionSource();
+        tm.OnTaskCompleted += (_, _, _, _, _, _, _) => completed.TrySetResult();
+
+        tm.StartTask(chatId: 104, task: "ping", displayText: "ping",
+            isSessionTask: false, source: TaskSource.UserMessage);
+
+        await completed.Task.WaitAsync(TimeSpan.FromSeconds(5));
+
+        // The marker is appended for every IsErrorResult cause — auth failure, RPC error,
+        // crash — so it must not name one of them.
+        await sink.Received().SendTextAsync(
+            104,
+            Arg.Is<string>(s => s.Contains("[incomplete") && !s.Contains("hit limit")),
+            Arg.Any<CancellationToken>());
+    }
+
+    [Fact]
+    public async Task CleanResult_WithText_CarriesNoIncompleteMarker()
+    {
+        var (text, isError) = await RunTask(chatId: 105, finalResult: "all done", isError: false);
+
+        Assert.False(isError);
+        Assert.DoesNotContain("[incomplete", text);
+    }
+}


### PR DESCRIPTION
## Summary

- `ClaudeExecutor` and `WarmupService` were dropping `is_error` result events on the floor. An OAuth token expiry on the co-cto agent surfaced only as `.claude.json` stderr noise, while the actual `Failed to authenticate: OAuth session expired and could not be refreshed` message returned in the result event was silently discarded — the container looked healthy in logs but every task hung with no reply.
- Added an error log in `ClaudeExecutor.cs` whenever a `result` event has `IsErrorResult == true`, showing `FinalResult`.
- Added an error branch in `WarmupService.cs` so warmup no longer logs "warmup complete" for error results.
- Same visibility now covers max-turns exhaustion and tool failures, not just auth.

## Test plan

- [ ] Build passes: `dotnet build src/Fleet.Agent/Fleet.Agent.csproj` (verified locally, 0 warnings 0 errors).
- [ ] With valid credentials: warmup logs "warmup complete" as before, no new error lines on healthy tasks.
- [ ] With expired/blank `.claude-credentials.json`: startup log shows `fail: WarmupService: warmup returned error — executor may be misconfigured: Failed to authenticate: ...` and any real task shows `fail: Claude result reported error: ...`.